### PR TITLE
Let multiple entities share the same task hierarchy

### DIFF
--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -1,7 +1,7 @@
 //! Contains the [`Plan`] component and types for operating on it.
 
 use alloc::collections::VecDeque;
-use bevy_ecs::{entity_disabling::Disabled, query::QueryEntityError};
+use bevy_ecs::{entity_disabling::Disabled, lifecycle::HookContext, query::QueryEntityError, world::DeferredWorld};
 
 use crate::{plan::mtr::Mtr, prelude::*};
 
@@ -9,11 +9,29 @@ pub(crate) mod execution;
 pub mod mtr;
 pub mod update;
 
+/// Specifies the domain used by a planner entity.
+#[derive(Component, Default)]
+#[component(on_insert = Self::on_insert_hook)]
+pub enum PlanDomain {
+    /// The planner entity defines its own task hierarchy.
+    #[default]
+    This,
+    /// The planner entity reuses a task hierarchy defined by another entity.
+    Entity(Entity),
+}
+
+impl PlanDomain {
+    fn on_insert_hook(mut world: DeferredWorld, context: HookContext) {
+        let mut cmds = world.commands();
+        cmds.entity(context.entity).insert_if_new(Plan::default());
+    }
+}
+
 /// A full plan of operators to execute. If this is empty, either through manually clearing it, inserting it, when it runs out of operators, or fails to execute them,
 /// the plan will be recomputed in the next fixed frame.
 #[derive(Component, Clone, Default, PartialEq, Eq, Reflect, Debug, Deref, DerefMut)]
 #[reflect(Component)]
-#[require(Props)]
+#[require(Props, PlanDomain)]
 pub struct Plan {
     /// The queue of planned [`Operator`]s to execute. This will get [`VecDeque::pop_front`]ed during plan execution.
     #[reflect(ignore)]

--- a/src/plan/update.rs
+++ b/src/plan/update.rs
@@ -4,7 +4,7 @@ use bevy_ecs::error::{DefaultErrorHandler, HandleError as _};
 use bevy_ecs::system::command::run_system_cached_with;
 use core::marker::PhantomData;
 
-use crate::plan::PlannedOperator;
+use crate::plan::{PlanDomain, PlannedOperator};
 use crate::plan::mtr::Mtr;
 use crate::prelude::*;
 use crate::task::compound::{DecomposeInput, DecomposeResult, TypeErasedCompoundTask};
@@ -62,6 +62,7 @@ pub(crate) fn update_plan(
 fn update_plan_inner(
     update: In<UpdatePlan>,
     world: &mut World,
+    mut plans: Local<QueryState<&PlanDomain>>,
     mut conditions: Local<QueryState<(Entity, &Condition)>>,
     mut effects: Local<QueryState<Entity, With<Effect>>>,
     mut tasks: Local<
@@ -71,7 +72,13 @@ fn update_plan_inner(
         >,
     >,
 ) -> Result {
-    let root = update.entity;
+    let executor = update.entity;
+    let Ok(domain) = plans.get(world, executor)
+    else { return Err(BevyError::from("Called `update_plan` on entity without Plan.")) };
+    let root = match domain {
+        PlanDomain::This => executor,
+        PlanDomain::Entity(entity) => *entity,
+    };
 
     let mut world_state = world.entity(update.entity).props().clone();
     let mut initial_conditions = Vec::new();

--- a/src/plan/update.rs
+++ b/src/plan/update.rs
@@ -174,13 +174,13 @@ fn update_plan_inner(
     plan.operators_total = op_entities;
 
     let old_plan = world
-        .entity(root)
+        .entity(executor)
         .get::<Plan>()
         .cloned()
         .unwrap_or_default();
-    world.entity_mut(root).insert(plan);
+    world.entity_mut(executor).insert(plan);
     world.trigger(ReplacePlan {
-        entity: root,
+        entity: executor,
         old: old_plan,
         _pd: PhantomData,
     });

--- a/tests/effects.rs
+++ b/tests/effects.rs
@@ -1,7 +1,7 @@
 //! Tests the application of effects
 
 use bevy::{log::LogPlugin, prelude::*, time::TimeUpdateStrategy};
-use bevy_bae::{plan::Plan, prelude::*};
+use bevy_bae::{plan::{Plan, PlanDomain}, prelude::*};
 use std::sync::Mutex;
 
 #[test]
@@ -145,6 +145,7 @@ fn assert_effects(behavior: impl Bundle, props: Vec<Vec<(&'static str, Value)>>)
         commands
             .spawn(behavior.lock().unwrap().take().unwrap())
             .insert_if_new(Name::new("root"))
+            .insert_if_new(PlanDomain::default())
             .trigger(UpdatePlan::new);
     });
     app.finish();

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -1,7 +1,7 @@
 //! Tests the plan execution
 
 use bevy::{log::LogPlugin, prelude::*, time::TimeUpdateStrategy};
-use bevy_bae::prelude::*;
+use bevy_bae::{plan::PlanDomain, prelude::*};
 use bevy_ecs::entity_disabling::Disabled;
 use std::sync::Mutex;
 
@@ -412,6 +412,7 @@ impl TestApp for App {
             commands
                 .spawn(behavior.lock().unwrap().take().unwrap())
                 .insert_if_new(Name::new("root"))
+                .insert_if_new(PlanDomain::default())
                 .trigger(UpdatePlan::new);
         })
         .add_systems(PreUpdate, |mut last_opt: ResMut<LastOpt>| {

--- a/tests/plan.rs
+++ b/tests/plan.rs
@@ -1,7 +1,7 @@
 //! Tests the plan generation
 
 use bevy::{log::LogPlugin, prelude::*, time::TimeUpdateStrategy};
-use bevy_bae::{plan::Plan, prelude::*};
+use bevy_bae::{plan::{Plan, PlanDomain}, prelude::*};
 use std::sync::Mutex;
 
 #[test]
@@ -233,6 +233,7 @@ fn assert_plan(behavior: impl Bundle, plan: Vec<&'static str>) {
         commands
             .spawn(behavior.lock().unwrap().take().unwrap())
             .insert_if_new(Name::new("root"))
+            .insert_if_new(PlanDomain::default())
             .trigger(UpdatePlan::new);
     });
     app.finish();


### PR DESCRIPTION
Hi. I'm unsure if this is what #6 describes by "multiple plans to run at the same time". I really like the idea of defining the task hierarchy in the ECS, but at least for my use case, I end up using a factory function for building the same plan for multiple entities:

```rust
fn enemy_plan() -> impl Bundle {
    (
        Plan::new(),
        Select,
        tasks! [
            ... a possibly large hierarchy
        ]
    )
}

cmds.spawn((Name("Enemy 1"), enemy_plan()));
cmds.spawn((Name("Enemy 2"), enemy_plan()));
...
cmds.spawn((Name("Enemy N"), enemy_plan()));
```

While this works, I think it's wasteful to spawn the exact the same tasks like above. For this reason, it was pretty clear that entities should share the same _domain_, which is nothing special: it's simply a task hierarchy without the `Plan` component. Entities can, then, share the same domain by specifying the `PlanDomain` component:

```rust
fn enemy_domain(cmds: &mut Commands) -> Entity {
    cmds.spawn((
        Select,
        tasks! [
            ... a possibly large hierarchy
        ]
    )).id()
}

// register the domain entity
let domain = enemy_domain(cmds);
// spawn N entities that independently create plans based on the shared domain
cmds.spawn((Name("Enemy 1"), PlanDomain::Entity(domain)));
cmds.spawn((Name("Enemy 2"), PlanDomain::Entity(domain)));
...
cmds.spawn((Name("Enemy N"), PlanDomain::Entity(domain)));
```

If not specified, `PlanDomain::This` is inserted by default, which is the current behaviour (the entity with `Plan` defines its own hierarchy).