### PR TITLE
Migrate to Bevy 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,22 +13,22 @@ keywords = ["bevy", "ai", "htn"]
 categories = ["game-development"]
 
 [dependencies]
-bevy_ecs = { version = "0.18", default-features = false, features = ["bevy_reflect"] }
-bevy_app = { version = "0.18", default-features = false }
-bevy_reflect = { version = "0.18", default-features = false }
-bevy_derive = { version = "0.18", default-features = false }
-bevy_ptr = { version = "0.18", default-features = false }
-bevy_utils = { version = "0.18", default-features = false }
+bevy_ecs = { version = "0.19", default-features = false, features = ["bevy_reflect"] }
+bevy_app = { version = "0.19", default-features = false }
+bevy_reflect = { version = "0.19", default-features = false }
+bevy_derive = { version = "0.19", default-features = false }
+bevy_ptr = { version = "0.19", default-features = false }
+bevy_utils = { version = "0.19", default-features = false }
 tracing = "0.1"
 
-bevy_mod_props = "2"
+bevy_mod_props = "3"
 
 estr = { version = "1" }
 variadics_please = "1"
 disqualified = "1.0.0"
 
 [dev-dependencies]
-bevy = { version = "0.18", default-features = true, features = ["track_location"] }
+bevy = { version = "0.19", default-features = true, features = ["track_location"] }
 
 [lints.rust]
 missing_docs = "warn"

--- a/src/plan/update.rs
+++ b/src/plan/update.rs
@@ -1,6 +1,6 @@
 //! Contains the [`UpdatePlan`] [`EntityEvent`].
 
-use bevy_ecs::error::{DefaultErrorHandler, HandleError as _};
+use bevy_ecs::error::FallbackErrorHandler;
 use bevy_ecs::system::command::run_system_cached_with;
 use core::marker::PhantomData;
 
@@ -49,13 +49,13 @@ pub struct ReplacePlan {
 pub(crate) fn update_plan(
     update: On<UpdatePlan>,
     mut commands: Commands,
-    error_handler: Option<Res<DefaultErrorHandler>>,
+    error_handler: Option<Res<FallbackErrorHandler>>,
 ) {
     let entity = update.entity;
     let error_handler = error_handler.map(|h| *h).unwrap_or_default();
-    commands.queue(
-        run_system_cached_with(update_plan_inner, UpdatePlan { entity })
-            .handle_error_with(error_handler.0),
+    commands.queue_handled(
+        run_system_cached_with(update_plan_inner, UpdatePlan { entity }),
+        error_handler.0,
     );
 }
 

--- a/src/task/operator.rs
+++ b/src/task/operator.rs
@@ -14,7 +14,7 @@ pub type OperatorId = SystemId<In<OperatorInput>, OperatorStatus>;
 /// The smallest unit of a plan, representing a single step. Contains a system that gets called for you during the execution of the plan.
 #[derive(Component, Reflect)]
 #[reflect(Component)]
-#[component(on_insert = Self::on_insert_hook, on_replace = Self::on_replace_hook)]
+#[component(on_insert = Self::on_insert_hook, on_discard = Self::on_discard_hook)]
 #[require(BaeTaskPresent)]
 pub struct Operator {
     #[reflect(ignore)]
@@ -83,7 +83,7 @@ impl Operator {
         world.get_mut::<Self>(context.entity).unwrap().system_id = Some(system_id);
     }
 
-    fn on_replace_hook(mut world: DeferredWorld, context: HookContext) {
+    fn on_discard_hook(mut world: DeferredWorld, context: HookContext) {
         let Some(system_id) = world
             .get::<Self>(context.entity)
             .and_then(|tt| tt.system_id)


### PR DESCRIPTION
A mechanical port, but can't build until `bevy_mod_props` ships for 0.19 -> NthTensor/bevy_mod_props#1

One point to coordinate: 0.19 ends `Props`' dual component/resource role. The open port in NthTensor/bevy_mod_props#1 turns `Props` into plain data behind an `EntityProps` component newtype, while this PR assumes `Props` stays a `Component`, the variant we run in our game with the full suite green. If NthTensor/bevy_mod_props#1 lands as written, the `require` and `get_mut` sites here will need a mechanical swap. Happy to update either way!